### PR TITLE
minor heartbeat/tests related tasks #65

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ script:
         - npm test
         - npm run test-integration
         - npm run test-integration-external
-

--- a/services/validatorWorker/follower.js
+++ b/services/validatorWorker/follower.js
@@ -2,7 +2,13 @@ const assert = require('assert')
 const isEqual = require('lodash.isequal');
 const db = require('../../db')
 const { persistAndPropagate } = require('./lib/propagation')
-const { isValidRootHash, toBNMap, getBalancesAfterFeesTree, toBNStringMap, onError, toStringBN  } = require('./lib')
+const { 
+	isValidRootHash, 
+	getBalancesAfterFeesTree, 
+	onError, 
+	toBNMap, 
+	toBNStringMap 
+} = require('./lib')
 const { isValidTransition, isHealthy } = require('./lib/followerRules')
 const producer = require('./producer')
 const { heartbeatIfNothingNew } = require('./heartbeat')
@@ -39,29 +45,11 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 	const { balancesAfterFees } = newMsg
 
 	if (!isValidTransition(channel, prevBalances, newBalances)) {
-		return onError(
-			channel,
-			adapter,
-			{
-				reason: 'InvalidTransition',
-				newMsg,
-				prevBalances,
-				newBalances 
-			}
-		)
+		return onError( channel, adapter, { reason: 'InvalidTransition', newMsg })
 	}
 
 	if(!isValidValidatorFees(channel, newBalances, balancesAfterFees)) {
-		return onError(
-			channel,
-			adapter,
-			{
-				reason: `InvalidValidatorFees`,
-				newMsg,
-				prevBalances,
-				newBalances 
-			}
-		)
+		return onError( channel, adapter, { reason: `InvalidValidatorFees`, newMsg })
 	}
 
 	const whoami = adapter.whoami()
@@ -71,31 +59,13 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 
 	// verify the stateRoot hash of newMsg: whether the stateRoot really represents this balance tree
 	if (!isValidRootHash(stateRoot, { channel, balancesAfterFees, adapter })){
-		return onError(
-			channel,
-			adapter,
-			{
-				reason: `InvalidRootHash`,
-				newMsg,
-				prevBalances,
-				newBalances  
-			}
-		)
+		return onError( channel, adapter, { reason: `InvalidRootHash`, newMsg })
 	}
 	// verify the signature of newMsg: whether it was signed by the leader validator
 	return adapter.verify(leader.id, stateRoot, signature)
 	.then(function(isValidSig) {
 		if (!isValidSig) {
-			return onError(
-				channel,
-				adapter,
-				{
-					reason: `InvalidSignature`,
-					newMsg,
-					prevBalances,
-					newBalances 
-				}
-			)
+			return onError( channel, adapter, { reason: `InvalidSignature`, newMsg })
 		}
     
 		const stateRootRaw = Buffer.from(stateRoot, 'hex')

--- a/services/validatorWorker/follower.js
+++ b/services/validatorWorker/follower.js
@@ -44,7 +44,6 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 
 
 	if (!isValidTransition(channel, prevBalances, newBalances)) {
-		console.log("invalid transition error")
 		return onError(
 			channel,
 			adapter,
@@ -85,7 +84,6 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 	return adapter.verify(leader.id, stateRoot, signature)
 	.then(function(isValidSig) {
 		if (!isValidSig) {
-			console.log("invalid signature")
 			return onError(
 				channel,
 				adapter,

--- a/services/validatorWorker/follower.js
+++ b/services/validatorWorker/follower.js
@@ -38,10 +38,6 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 	const newBalances = toBNMap(newMsg.balances)
 	const { balancesAfterFees } = newMsg
 
-	const prevBalancesString = toStringBN(prevBalances)
-	const newBalancesString = toStringBN(newBalances)
-
-
 	if (!isValidTransition(channel, prevBalances, newBalances)) {
 		return onError(
 			channel,
@@ -49,8 +45,8 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 			{
 				reason: 'InvalidTransition',
 				newMsg,
-				prevBalancesString, 
-				newBalancesString 
+				prevBalances,
+				newBalances 
 			}
 		)
 	}
@@ -62,8 +58,8 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 			{
 				reason: `InvalidValidatorFees`,
 				newMsg,
-				prevBalancesString, 
-				newBalancesString 
+				prevBalances,
+				newBalances 
 			}
 		)
 	}
@@ -81,8 +77,8 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 			{
 				reason: `InvalidRootHash`,
 				newMsg,
-				prevBalancesString, 
-				newBalancesString 
+				prevBalances,
+				newBalances  
 			}
 		)
 	}
@@ -96,8 +92,8 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 				{
 					reason: `InvalidSignature`,
 					newMsg,
-					prevBalancesString, 
-					newBalancesString 
+					prevBalances,
+					newBalances 
 				}
 			)
 		}

--- a/services/validatorWorker/follower.js
+++ b/services/validatorWorker/follower.js
@@ -91,8 +91,7 @@ function isValidValidatorFees(channel, balances, balancesAfterFees) {
 // e.g. validating on POST /validator-messages (to get the previous), and a public API to get the latest msgs of a type
 function getLatestMsg(channelId, from, type) {
 	const validatorMsgCol = db.getMongo().collection('validatorMessages')
-	// @TODO: this assumption of getting the latest is flawed; won't work if it's within the same second: https://docs.mongodb.com/manual/reference/method/ObjectId/
-	// it is very important that we get this right, since it will be used to gather data about the channel state too
+
 	return validatorMsgCol.find({
 		channelId,
 		from: from,

--- a/services/validatorWorker/follower.js
+++ b/services/validatorWorker/follower.js
@@ -44,6 +44,7 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 
 
 	if (!isValidTransition(channel, prevBalances, newBalances)) {
+		console.log("invalid transition error")
 		return onError(
 			channel,
 			adapter,
@@ -84,6 +85,7 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 	return adapter.verify(leader.id, stateRoot, signature)
 	.then(function(isValidSig) {
 		if (!isValidSig) {
+			console.log("invalid signature")
 			return onError(
 				channel,
 				adapter,
@@ -104,6 +106,7 @@ function onNewState(adapter, {channel, balances, newMsg, approveMsg}) {
 				stateRoot: stateRoot,
 				isHealthy: isHealthy(balances, newBalances),
 				signature,
+				created: Date.now()
 			})
 		})
 	})
@@ -125,7 +128,7 @@ function getLatestMsg(channelId, from, type) {
 		from: from,
 		'msg.type': type,
 	})
-	.sort({ _id: -1 })
+	.sort({ 'msg.created': -1 })
 	.limit(1)
 	.toArray()
 	.then(function([o]) {

--- a/services/validatorWorker/leader.js
+++ b/services/validatorWorker/leader.js
@@ -25,6 +25,7 @@ function afterProducer(adapter, {channel, newStateTree, balancesAfterFees}) {
 			...newStateTree,
 			stateRoot,
 			signature,
+			created: Date.now()
 		})
 	})
 }

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -81,10 +81,14 @@ function invalidNewState(channel, adapter, { reason, newMsg}) {
 }
 
 function onError(channel, adapter, { reason, newMsg, prevBalancesString, newBalancesString }) {
+	console.log(`invalid ${reason}`)
+
 	const errMsg = getErrorMsg(reason, channel, prevBalancesString, newBalancesString)
 
 	return invalidNewState(channel, adapter, { reason, newMsg})
 	.then(function(){
+		console.log(`invalid ${reason} 2`)
+
 		console.error(errMsg)
 		return { nothingNew: true }
 	})

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -81,13 +81,10 @@ function invalidNewState(channel, adapter, { reason, newMsg}) {
 }
 
 function onError(channel, adapter, { reason, newMsg, prevBalancesString, newBalancesString }) {
-	console.log(`invalid ${reason}`)
-
 	const errMsg = getErrorMsg(reason, channel, prevBalancesString, newBalancesString)
 
 	return invalidNewState(channel, adapter, { reason, newMsg})
 	.then(function(){
-		console.log(`invalid ${reason} 2`)
 
 		console.error(errMsg)
 		return { nothingNew: true }

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -24,7 +24,6 @@ function toBNMap(raw) {
 	return balances
 }
 
-<<<<<<< HEAD
 // returns BN
 function getValidatorFee(publisherBalance, totalValidatorFee, depositAmount) {
 	const numerator = depositAmount.sub(totalValidatorFee)
@@ -63,8 +62,6 @@ function toBNStringMap(raw){
 	return balances
 }
 
-module.exports = { getStateRootHash, isValidRootHash, toBNMap, getBalancesAfterFeesTree, toBNStringMap }
-=======
 function toStringBN(raw) {
 	let result = ``
 	Object.entries(raw).forEach(([acc, bal]) => result = `${result} ${acc}: ${bal.toString()}`)
@@ -96,5 +93,14 @@ function getErrorMsg(type, channel, prevBalancesString, newBalancesString ){
 			 prevBalances: ${prevBalancesString}, \n newBalances: ${newBalancesString}`
 }
 
-module.exports = { getStateRootHash, isValidRootHash, toBNMap, invalidNewState, onError, toStringBN, getErrorMsg }
->>>>>>> ed5fe23... added invalidNewState, refactor tests
+module.exports = { 
+	getStateRootHash, 
+	isValidRootHash, 
+	toBNMap,
+	invalidNewState, 
+	onError, 
+	toStringBN, 
+	getErrorMsg, 
+	toBNStringMap, 
+	getBalancesAfterFeesTree,
+}

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -62,12 +62,6 @@ function toBNStringMap(raw){
 	return balances
 }
 
-function toStringBN(raw) {
-	let result = ``
-	Object.entries(raw).forEach(([acc, bal]) => result = `${result} ${acc}: ${bal.toString()}`)
-	return result
-}
-
 function invalidNewState(channel, adapter, { reason, newMsg}) {
 	// quirk: type is overiding type in newMsg
 	return persist(adapter, channel, {
@@ -82,13 +76,12 @@ function onError(channel, adapter, { reason, newMsg }) {
 
 	return invalidNewState(channel, adapter, { reason, newMsg })
 	.then(function(){
-
 		console.error(errMsg)
 		return { nothingNew: true }
 	})
 }
 
-function getErrorMsg(reason, channel ){
+function getErrorMsg(reason, channel) {
 	return `validatatorWorker: ${channel.id}: ${reason} requested in NewState`
 }
 
@@ -98,7 +91,6 @@ module.exports = {
 	toBNMap,
 	invalidNewState, 
 	onError, 
-	toStringBN, 
 	getErrorMsg, 
 	toBNStringMap, 
 	getBalancesAfterFeesTree,

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -77,7 +77,10 @@ function invalidNewState(channel, adapter, { reason, newMsg}) {
 	})
 }
 
-function onError(channel, adapter, { reason, newMsg, prevBalancesString, newBalancesString }) {
+function onError(channel, adapter, { reason, newMsg, prevBalances, newBalances }) {
+	const prevBalancesString = toStringBN(prevBalances)
+	const newBalancesString = toStringBN(newBalances)
+
 	const errMsg = getErrorMsg(reason, channel, prevBalancesString, newBalancesString)
 
 	return invalidNewState(channel, adapter, { reason, newMsg})

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -77,13 +77,10 @@ function invalidNewState(channel, adapter, { reason, newMsg}) {
 	})
 }
 
-function onError(channel, adapter, { reason, newMsg, prevBalances, newBalances }) {
-	const prevBalancesString = toStringBN(prevBalances)
-	const newBalancesString = toStringBN(newBalances)
+function onError(channel, adapter, { reason, newMsg }) {
+	const errMsg = getErrorMsg(reason, channel)
 
-	const errMsg = getErrorMsg(reason, channel, prevBalancesString, newBalancesString)
-
-	return invalidNewState(channel, adapter, { reason, newMsg})
+	return invalidNewState(channel, adapter, { reason, newMsg })
 	.then(function(){
 
 		console.error(errMsg)
@@ -91,9 +88,8 @@ function onError(channel, adapter, { reason, newMsg, prevBalances, newBalances }
 	})
 }
 
-function getErrorMsg(type, channel, prevBalancesString, newBalancesString ){
-	return `validatatorWorker: ${channel.id}: ${type} requested in NewState 
-			 prevBalances: ${prevBalancesString}, \n newBalances: ${newBalancesString}`
+function getErrorMsg(reason, channel ){
+	return `validatatorWorker: ${channel.id}: ${reason} requested in NewState`
 }
 
 module.exports = { 

--- a/services/validatorWorker/lib/index.js
+++ b/services/validatorWorker/lib/index.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const BN = require('bn.js')
-
+const { persist } = require('./propagation')
 function getStateRootHash(channel, balances, adapter){
 	// Note: MerkleTree takes care of deduplicating and sorting
 	const elems = Object.keys(balances).map(
@@ -24,6 +24,7 @@ function toBNMap(raw) {
 	return balances
 }
 
+<<<<<<< HEAD
 // returns BN
 function getValidatorFee(publisherBalance, totalValidatorFee, depositAmount) {
 	const numerator = depositAmount.sub(totalValidatorFee)
@@ -63,3 +64,36 @@ function toBNStringMap(raw){
 }
 
 module.exports = { getStateRootHash, isValidRootHash, toBNMap, getBalancesAfterFeesTree, toBNStringMap }
+=======
+function toStringBN(raw) {
+	let result = ``
+	Object.entries(raw).forEach(([acc, bal]) => result = `${result} ${acc}: ${bal.toString()}`)
+	return result
+}
+
+function invalidNewState(channel, adapter, { reason, newMsg}) {
+	// quirk: type is overiding type in newMsg
+	return persist(adapter, channel, {
+		...newMsg,
+		type: 'InvalidNewState',
+		reason,
+	})
+}
+
+function onError(channel, adapter, { reason, newMsg, prevBalancesString, newBalancesString }) {
+	const errMsg = getErrorMsg(reason, channel, prevBalancesString, newBalancesString)
+
+	return invalidNewState(channel, adapter, { reason, newMsg})
+	.then(function(){
+		console.error(errMsg)
+		return { nothingNew: true }
+	})
+}
+
+function getErrorMsg(type, channel, prevBalancesString, newBalancesString ){
+	return `validatatorWorker: ${channel.id}: ${type} requested in NewState 
+			 prevBalances: ${prevBalancesString}, \n newBalances: ${newBalancesString}`
+}
+
+module.exports = { getStateRootHash, isValidRootHash, toBNMap, invalidNewState, onError, toStringBN, getErrorMsg }
+>>>>>>> ed5fe23... added invalidNewState, refactor tests

--- a/test/integration.js
+++ b/test/integration.js
@@ -10,7 +10,8 @@ const {
     genImpressions,
     getDummySig,
 	wait,
-	filterInvalidNewStateMSg
+	filterInvalidNewStateMSg,
+	incrementKeys,
 } = require('./lib')
 
 const cfg = require('../cfg')
@@ -195,8 +196,8 @@ tape('POST /channel/{id}/{validator-messages}: wrong signature', function(t) {
 		// increase the state tree balance by 1
 		Object.keys(balances).forEach((item) => (incBalances[item] = `${parseInt(balances[item])+1}`))
 
-
-		stateRoot = getStateRootHash({id: dummyVals.channel.id}, incBalances, dummyAdapter)
+		const balancesAfterFees = getBalancesAfterFeesTree(incBalances, dummyVals.channel)
+		stateRoot = getStateRootHash({id: dummyVals.channel.id}, balancesAfterFees, dummyAdapter)
 		signature = getDummySig(stateRoot, "awesomeLeader12")
 		
 		return fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages`, {

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 const tape = require('tape')
 const fetch = require('node-fetch')
-const BN = require('bn.js')
 const { Channel, MerkleTree } = require('adex-protocol-eth/js')
 const { getStateRootHash, getBalancesAfterFeesTree, toBNStringMap } = require('../services/validatorWorker/lib')
 const dummyAdapter = require('../adapters/dummy')

--- a/test/integration.js
+++ b/test/integration.js
@@ -376,6 +376,7 @@ tape('cannot exceed channel deposit', function(t) {
 		// 1 event pays 1 token for now
 		// @TODO make this work with a more complex model
 		const evCount = resp.channel.depositAmount + 1
+		
 		return Promise.all([leaderUrl, followerUrl].map(url =>
 			postEvents(url, dummyVals.channel.id, genImpressions(evCount))
 		))

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,6 +5,13 @@ const BN = require('bn.js')
 const { Channel, MerkleTree } = require('adex-protocol-eth/js')
 const { getStateRootHash, getBalancesAfterFeesTree, toBNStringMap } = require('../services/validatorWorker/lib')
 const dummyAdapter = require('../adapters/dummy')
+const {
+	postEvents,
+    genImpressions,
+    getDummySig,
+	wait,
+	filterInvalidNewStateMSg
+} = require('./lib')
 
 const cfg = require('../cfg')
 const dummyVals = require('./prep-db/mongo')
@@ -18,65 +25,7 @@ const expectedDepositAmnt = dummyVals.channel.depositAmount
 const waitTime = cfg.AGGR_THROTTLE + cfg.SNOOZE_TIME*2 + cfg.WAIT_TIME*2 + 500
 const waitAggrTime = cfg.AGGR_THROTTLE + 500
 
-tape('/channel/list', function(t) {
-	fetch(`${leaderUrl}/channel/list`)
-	.then(res => res.json())
-	.then(function(resp) {
-		t.ok(Array.isArray(resp.channels), 'resp.channels is an array')
-		t.equal(resp.channels.length, 1, 'resp.channels is the right len')
-		t.equal(resp.channels[0].status, 'live', 'channel is the right status')
-		t.end()
-	})
-	.catch(err => t.fail(err))
-	// @TODO: test channel list filters if there are any
-})
-
-tape('/channel/{id}/{status,tree}: non existant channel', function(t) {
-	Promise.all(['status', 'tree'].map(path =>
-		fetch(`${leaderUrl}/channel/xxxtentacion/${path}`)
-		.then(function(res) {
-			t.equal(res.status, 404, 'status should be 404')
-		})
-	))
-	.then(() => t.end())
-	.catch(err => t.fail(err))
-})
-
-tape('POST /channel/{id}/events: non existant channel', function(t) {
-	return postEvents(leaderUrl, 'xxxtentacion', [])
-	.then(function(resp) {
-		t.equal(resp.status, 404, 'status should be 404')
-		t.end()
-	})
-})
-
-tape('/channel/{id}/status', function(t) {
-	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/tree`)
-	.then(res => res.json())
-	.then(function(resp) {
-		t.ok(resp.channel, 'has resp.channel')
-		t.equal(resp.channel.status, 'live', 'channel has right status')
-		t.equal(resp.channel.depositAmount, expectedDepositAmnt, 'depositAmount is as expected')
-		t.end()
-	})
-	.catch(err => t.fail(err))
-})
-
-tape('/channel/{id}/tree', function(t) {
-	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/tree`)
-	.then(res => res.json())
-	.then(function(resp) {
-		t.ok(resp.channel, 'has resp.channel')
-		t.equal(resp.channel.status, 'live', 'channel has right status')
-		t.deepEqual(resp.balances, {}, 'channel has balances')
-		t.equal(new Date(resp.lastEvAggr).getTime(0), 0, 'lastEvAggr is 0')
-		t.end()
-	})
-	.catch(err => t.fail(err))
-})
-
 // @TODO: validator-messages, and it's filters
-
 tape('submit events and ensure they are accounted for', function(t) {
 	const evs = genImpressions(3).concat(genImpressions(2, 'anotherPublisher'))
 	const expectedBal = '3'
@@ -158,26 +107,6 @@ tape('submit events and ensure they are accounted for', function(t) {
 	.catch(err => t.fail(err))
 })
 
-tape('/channel/{id}/events-aggregates', function(t) {
-	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/events-aggregates`, {
-		method: 'GET',
-		headers: {
-			'authorization': `Bearer ${dummyVals.auth.publisher}`,
-			'content-type': 'application/json',
-		},
-	})
-	.then(res => {
-		return res.json()
-	})
-	.then(function(resp) {
-		t.ok(resp.channel, 'has resp.channel')
-		t.ok(resp.events, 'has resp.events')
-		t.ok(resp.events.length >= 1, "should have events of min legnth 1")
-		t.end()
-	})
-	.catch(err => t.fail(err))
-})
-
 
 tape('health works correctly', function(t) {
 	const toFollower = 8
@@ -253,29 +182,9 @@ tape('heartbeat works correctly', function(t){
 	.catch(err => t.fail(err))
 })
 
-tape('POST /channel/{id}/{events,validator-messages}: wrong authentication', function(t) {
-	Promise.all(
-		['events', 'validator-messages'].map(path =>
-			fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/${path}`, {
-				method: 'POST',
-				headers: {
-					'authorization': `Bearer WRONG AUTH`,
-					'content-type': 'application/json',
-				},
-				body: JSON.stringify({messages:[]}),
-			})
-			.then(function(resp) {
-				t.equal(resp.status, 401, 'status must be Unauthorized')
-			})
-		)
-	)
-	.then(() => t.end())
-	.catch(err => t.fail(err))
-})
-
 tape('POST /channel/{id}/{validator-messages}: wrong signature', function(t) {
 	let stateRoot = ""
-
+	let signature = ""
 	fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages/${dummyVals.ids.leader}/NewState?limit=1`)
 	.then(res => res.json())
 	.then(function(res) {
@@ -285,9 +194,14 @@ tape('POST /channel/{id}/{validator-messages}: wrong signature', function(t) {
 		// increase the state tree balance by 1
 		Object.keys(balances).forEach((item) => (incBalances[item] = `${parseInt(balances[item])+1}`))
 
+<<<<<<< HEAD
 		const balancesAfterFees = getBalancesAfterFeesTree(incBalances, dummyVals.channel)
 		const stateRoot = getStateRootHash({id: dummyVals.channel.id}, balancesAfterFees, dummyAdapter)
 
+=======
+		stateRoot = getStateRootHash({id: dummyVals.channel.id}, incBalances, dummyAdapter)
+		signature = getDummySig(stateRoot, "awesomeLeader1")
+>>>>>>> ed5fe23... added invalidNewState, refactor tests
 		return fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages`, {
 			method: 'POST',
 			headers: {
@@ -302,7 +216,7 @@ tape('POST /channel/{id}/{validator-messages}: wrong signature', function(t) {
 					balancesAfterFees: toBNStringMap(balancesAfterFees),
 					lastEvAggr: "2019-01-23T09:09:29.959Z",
 					// sign by awesomeLeader1 rather than awesomeLeader
-					signature: getDummySig(stateRoot, "awesomeLeader1")
+					signature,
 				}]
 			}),
 		})
@@ -317,6 +231,20 @@ tape('POST /channel/{id}/{validator-messages}: wrong signature', function(t) {
 		const lastApprove = resp.validatorMessages.find(x => x.msg.stateRoot === stateRoot)
 		t.equal(lastApprove, undefined, 'follower should not sign state with invalid signature')
 		t.end()
+	})
+	.then(function(){
+		return fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages/${dummyVals.ids.follower}/InvalidNewState`)
+		.then(res => res.json())
+	})
+	.then(function(resp){
+		const message = filterInvalidNewStateMSg(resp.validatorMessages, { reason: 'InvalidSignature', 'stateRoot': stateRoot })[0]
+		
+		t.ok(message, 'should have an invalid new state')
+		t.equal(message.msg.type, 'InvalidNewState', 'should have an invalid new state')
+		t.equal(message.msg.reason, 'InvalidSignature', 'reason should be invalid root hash')
+		t.equal(message.msg.stateRoot, stateRoot, 'should have state root')
+		t.equal(message.msg.signature, signature, 'should have signature')
+
 	})
 	.catch(err => t.fail(err))
 })
@@ -361,6 +289,18 @@ tape('POST /channel/{id}/{validator-messages}: wrong (deceptive) root hash', fun
 		const lastApprove = resp.validatorMessages.find(x => x.msg.stateRoot === deceptiveRootHash)
 		t.equal(lastApprove, undefined, 'follower should not sign state with wrong root hash')
 		t.end()
+	})
+	.then(function(){
+		return fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages/${dummyVals.ids.follower}/InvalidNewState`)
+		.then(res => res.json())
+	})
+	.then(function(resp){
+		const message = filterInvalidNewStateMSg(resp.validatorMessages, { reason: 'InvalidRootHash', 'stateRoot': deceptiveRootHash })[0]
+		
+		t.ok(message, 'should have an invalid new state')
+		t.equal(message.msg.type, 'InvalidNewState', 'should have an invalid new state')
+		t.equal(message.msg.reason, 'InvalidRootHash', 'reason should be invalid root hash')
+		t.equal(message.msg.stateRoot, deceptiveRootHash, 'should have the deceptive root hash')
 	})
 	.catch(err => t.fail(err))
 })
@@ -409,51 +349,6 @@ tape('POST /channel/{id}/{validator-messages}: wrong (deceptive) balanceAfterFee
 })
 
 
-tape('POST /channel/{id}/validator-messages: malformed messages (leader -> follower)', function(t) {
-	Promise.all([
-		null,
-		{ type: 1 },
-		{ type: 'NewState' },
-		{ type: 'NewState', balances: 'iamobject' },
-		{ type: 'ApproveState', stateRoot: 'notlongenough', signature: 'something' },
-	].map(msg =>
-		fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages`, {
-			method: 'POST',
-			headers: {
-				'authorization': `Bearer ${dummyVals.auth.leader}`,
-				'content-type': 'application/json',
-			},
-			body: JSON.stringify({ messages: [msg] }),
-		})
-		.then(function(resp) {
-			t.equal(resp.status, 400, 'status must be BadRequest')
-		})
-	))
-	.then(() => t.end())
-	.catch(err => t.fail(err))
-})
-
-tape('POST /channel/{id}/events: malformed events', function(t) {
-	Promise.all([
-		null,
-		{ type: 1 },
-		{ type: null },
-	].map(ev =>
-		fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/events`, {
-			method: 'POST',
-			headers: {
-				'authorization': `Bearer ${dummyVals.auth.user}`,
-				'content-type': 'application/json',
-			},
-			body: JSON.stringify({ events: [ev] }),
-		})
-		.then(function(resp) {
-			t.equal(resp.status, 400, 'status is BadRequest')
-		})
-	))
-	.then(() => t.end())
-	.catch(err => t.fail(err))
-})
 
 tape('cannot exceed channel deposit', function(t) {
 	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/status`)
@@ -482,6 +377,7 @@ tape('cannot exceed channel deposit', function(t) {
 	.catch(err => t.fail(err))
 })
 
+<<<<<<< HEAD
 function postEvents(url, channelId, events) {
 	return fetch(`${url}/channel/${channelId}/events`, {
 		method: 'POST',
@@ -515,6 +411,8 @@ function incrementKeys(raw){
 	Object.keys(raw).forEach((item) => ( incBalances[item] = (new BN(raw[item], 10).add(new BN(1))).toString(10) ))
 	return incBalances
 }
+=======
+>>>>>>> ed5fe23... added invalidNewState, refactor tests
 // @TODO sentry tests: ensure every middleware case is accounted for: channelIfExists, channelIfActive, auth
 // @TODO consider separate tests for when/if/how /tree is updated? or unit tests for the event aggregator
 // @TODO tests for the adapters and especially ewt

--- a/test/integration.js
+++ b/test/integration.js
@@ -107,6 +107,25 @@ tape('submit events and ensure they are accounted for', function(t) {
 	.catch(err => t.fail(err))
 })
 
+tape('/channel/{id}/events-aggregates', function(t) {	
+	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/events-aggregates`, {	
+		method: 'GET',	
+		headers: {	
+			'authorization': `Bearer ${dummyVals.auth.publisher}`,	
+			'content-type': 'application/json',	
+		},	
+	})	
+	.then(res => {	
+		return res.json()	
+	})	
+	.then(function(resp) {	
+		t.ok(resp.channel, 'has resp.channel')	
+		t.ok(resp.events, 'has resp.events')	
+		t.ok(resp.events.length >= 1, "should have events of min legnth 1")	
+		t.end()	
+	})	
+	.catch(err => t.fail(err))	
+})
 
 tape('health works correctly', function(t) {
 	const toFollower = 8

--- a/test/lib.js
+++ b/test/lib.js
@@ -33,11 +33,11 @@ function wait(ms) {
 	return new Promise((resolve, _) => setTimeout(resolve, ms))
 }
 
-function filterInvalidNewStateMSg(messages, properties){
+function filterInvalidNewStateMSg(messages, filter){
     assert.ok(Array.isArray(messages), 'messages should be array')
     
     messages = messages.filter(
-        (msg) => msg.msg.reason == properties.reason && msg.msg.stateRoot == properties.stateRoot
+        (msg) => msg.msg.reason == filter.reason && msg.msg.stateRoot == filter.stateRoot
     )
 
     return messages

--- a/test/lib.js
+++ b/test/lib.js
@@ -1,0 +1,51 @@
+
+const assert = require('assert')
+const dummyVals = require('./prep-db/mongo')
+const defaultPubName = dummyVals.ids.publisher
+const fetch = require('node-fetch')
+
+function postEvents(url, channelId, events) {
+	return fetch(`${url}/channel/${channelId}/events`, {
+		method: 'POST',
+		headers: {
+			'authorization': `Bearer ${dummyVals.auth.user}`,
+			'content-type': 'application/json',
+		},
+		body: JSON.stringify({ events }),
+	})
+}
+
+function genImpressions(n, pubName) {
+	const events = []
+	for (let i=0; i<n; i++) events.push({
+		type: 'IMPRESSION',
+		publisher: pubName || defaultPubName,
+	})
+	return events
+}
+
+function getDummySig(hash, from) {
+	return `Dummy adapter signature for ${hash} by ${from}`
+}
+
+function wait(ms) {
+	return new Promise((resolve, _) => setTimeout(resolve, ms))
+}
+
+function filterInvalidNewStateMSg(messages, properties){
+    assert.ok(Array.isArray(messages), 'messages should be array')
+    
+    messages = messages.filter(
+        (msg) => msg.msg.reason == properties.reason && msg.msg.stateRoot == properties.stateRoot
+    )
+
+    return messages
+}
+
+module.exports = {
+    postEvents,
+    genImpressions,
+    getDummySig,
+    wait,
+    filterInvalidNewStateMSg
+}

--- a/test/lib.js
+++ b/test/lib.js
@@ -42,10 +42,17 @@ function filterInvalidNewStateMSg(messages, properties){
     return messages
 }
 
+function incrementKeys(raw){	
+	let incBalances = {}	
+	Object.keys(raw).forEach((item) => ( incBalances[item] = (new BN(raw[item], 10).add(new BN(1))).toString(10) ))	
+	return incBalances	
+}
+
 module.exports = {
     postEvents,
     genImpressions,
     getDummySig,
     wait,
-    filterInvalidNewStateMSg
+	filterInvalidNewStateMSg,
+	incrementKeys,
 }

--- a/test/lib.js
+++ b/test/lib.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const dummyVals = require('./prep-db/mongo')
 const defaultPubName = dummyVals.ids.publisher
 const fetch = require('node-fetch')
+const BN = require('bn.js')
 
 function postEvents(url, channelId, events) {
 	return fetch(`${url}/channel/${channelId}/events`, {

--- a/test/routes.js
+++ b/test/routes.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+const tape = require('tape')
+const fetch = require('node-fetch')
+const {
+	postEvents,
+} = require('./lib')
+
+const dummyVals = require('./prep-db/mongo')
+const leaderUrl = dummyVals.channel.spec.validators[0].url
+const expectedDepositAmnt = dummyVals.channel.depositAmount
+
+tape('/channel/list', function(t) {
+	fetch(`${leaderUrl}/channel/list`)
+	.then(res => res.json())
+	.then(function(resp) {
+		t.ok(Array.isArray(resp.channels), 'resp.channels is an array')
+		t.equal(resp.channels.length, 1, 'resp.channels is the right len')
+		t.equal(resp.channels[0].status, 'live', 'channel is the right status')
+		t.end()
+	})
+	.catch(err => t.fail(err))
+	// @TODO: test channel list filters if there are any
+})
+
+tape('/channel/{id}/{status,tree}: non existant channel', function(t) {
+	Promise.all(['status', 'tree'].map(path =>
+		fetch(`${leaderUrl}/channel/xxxtentacion/${path}`)
+		.then(function(res) {
+			t.equal(res.status, 404, 'status should be 404')
+		})
+	))
+	.then(() => t.end())
+	.catch(err => t.fail(err))
+})
+
+tape('POST /channel/{id}/events: non existant channel', function(t) {
+	return postEvents(leaderUrl, 'xxxtentacion', [])
+	.then(function(resp) {
+		t.equal(resp.status, 404, 'status should be 404')
+		t.end()
+	})
+})
+
+tape('/channel/{id}/status', function(t) {
+	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/tree`)
+	.then(res => res.json())
+	.then(function(resp) {
+		t.ok(resp.channel, 'has resp.channel')
+		t.equal(resp.channel.status, 'live', 'channel has right status')
+		t.equal(resp.channel.depositAmount, expectedDepositAmnt, 'depositAmount is as expected')
+		t.end()
+	})
+	.catch(err => t.fail(err))
+})
+
+tape('/channel/{id}/tree', function(t) {
+	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/tree`)
+	.then(res => res.json())
+	.then(function(resp) {
+		t.ok(resp.channel, 'has resp.channel')
+		t.equal(resp.channel.status, 'live', 'channel has right status')
+		t.deepEqual(resp.balances, {}, 'channel has balances')
+		t.equal(new Date(resp.lastEvAggr).getTime(0), 0, 'lastEvAggr is 0')
+		t.end()
+	})
+	.catch(err => t.fail(err))
+})
+
+tape('/channel/{id}/events-aggregates', function(t) {
+	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/events-aggregates`, {
+		method: 'GET',
+		headers: {
+			'authorization': `Bearer ${dummyVals.auth.publisher}`,
+			'content-type': 'application/json',
+		},
+	})
+	.then(res => {
+		return res.json()
+	})
+	.then(function(resp) {
+		t.ok(resp.channel, 'has resp.channel')
+		t.ok(resp.events, 'has resp.events')
+		t.ok(resp.events.length >= 1, "should have events of min legnth 1")
+		t.end()
+	})
+	.catch(err => t.fail(err))
+})
+
+tape('POST /channel/{id}/validator-messages: malformed messages (leader -> follower)', function(t) {
+	Promise.all([
+		null,
+		{ type: 1 },
+		{ type: 'NewState' },
+		{ type: 'NewState', balances: 'iamobject' },
+		{ type: 'ApproveState', stateRoot: 'notlongenough', signature: 'something' },
+	].map(msg =>
+		fetch(`${followerUrl}/channel/${dummyVals.channel.id}/validator-messages`, {
+			method: 'POST',
+			headers: {
+				'authorization': `Bearer ${dummyVals.auth.leader}`,
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({ messages: [msg] }),
+		})
+		.then(function(resp) {
+			t.equal(resp.status, 400, 'status must be BadRequest')
+		})
+	))
+	.then(() => t.end())
+	.catch(err => t.fail(err))
+})
+
+tape('POST /channel/{id}/events: malformed events', function(t) {
+	Promise.all([
+		null,
+		{ type: 1 },
+		{ type: null },
+	].map(ev =>
+		fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/events`, {
+			method: 'POST',
+			headers: {
+				'authorization': `Bearer ${dummyVals.auth.user}`,
+				'content-type': 'application/json',
+			},
+			body: JSON.stringify({ events: [ev] }),
+		})
+		.then(function(resp) {
+			t.equal(resp.status, 400, 'status is BadRequest')
+		})
+	))
+	.then(() => t.end())
+	.catch(err => t.fail(err))
+})
+
+tape('POST /channel/{id}/{events,validator-messages}: wrong authentication', function(t) {
+	Promise.all(
+		['events', 'validator-messages'].map(path =>
+			fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/${path}`, {
+				method: 'POST',
+				headers: {
+					'authorization': `Bearer WRONG AUTH`,
+					'content-type': 'application/json',
+				},
+				body: JSON.stringify({messages:[]}),
+			})
+			.then(function(resp) {
+				t.equal(resp.status, 401, 'status must be Unauthorized')
+			})
+		)
+	)
+	.then(() => t.end())
+	.catch(err => t.fail(err))
+})

--- a/test/routes.js
+++ b/test/routes.js
@@ -4,11 +4,18 @@ const tape = require('tape')
 const fetch = require('node-fetch')
 const {
 	postEvents,
+	genImpressions,
+	wait
 } = require('./lib')
 
+const cfg = require('../cfg')
 const dummyVals = require('./prep-db/mongo')
 const leaderUrl = dummyVals.channel.spec.validators[0].url
+const followerUrl = dummyVals.channel.spec.validators[1].url
+const defaultPubName = dummyVals.ids.publisher
 const expectedDepositAmnt = dummyVals.channel.depositAmount
+
+const waitTime = cfg.AGGR_THROTTLE + cfg.SNOOZE_TIME*2 + cfg.WAIT_TIME*2 + 500
 
 tape('/channel/list', function(t) {
 	fetch(`${leaderUrl}/channel/list`)
@@ -62,26 +69,6 @@ tape('/channel/{id}/tree', function(t) {
 		t.equal(resp.channel.status, 'live', 'channel has right status')
 		t.deepEqual(resp.balances, {}, 'channel has balances')
 		t.equal(new Date(resp.lastEvAggr).getTime(0), 0, 'lastEvAggr is 0')
-		t.end()
-	})
-	.catch(err => t.fail(err))
-})
-
-tape('/channel/{id}/events-aggregates', function(t) {
-	fetch(`${leaderUrl}/channel/${dummyVals.channel.id}/events-aggregates`, {
-		method: 'GET',
-		headers: {
-			'authorization': `Bearer ${dummyVals.auth.publisher}`,
-			'content-type': 'application/json',
-		},
-	})
-	.then(res => {
-		return res.json()
-	})
-	.then(function(resp) {
-		t.ok(resp.channel, 'has resp.channel')
-		t.ok(resp.events, 'has resp.events')
-		t.ok(resp.events.length >= 1, "should have events of min legnth 1")
 		t.end()
 	})
 	.catch(err => t.fail(err))

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -40,6 +40,7 @@ if [ -n "$RUN_EXTERNAL" ]; then
 	LEADER_DATABASE=$LEAD_MONGO FOLLOWER_DATABASE=$FOLLOW_MONGO npm run test-local
 else 
 	./test/integration.js
+	./test/routes.js
 fi
 
 exitCode=$?
@@ -47,18 +48,18 @@ exitCode=$?
 # end all jobs (sentries, workers)
 pkill -P $$
 
-if [ $exitCode -eq 0 ]; then
-	echo "cleaning up DB"
-	mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
-	mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
-else
-	echo -e "\033[0;31mTests failed: waiting 20s before cleaning the database (press ctrl-C to avoid cleanup)\033[0m"
-	echo "MongoDB database names: $LEAD_MONGO, $FOLLOW_MONGO"
-	(
-		sleep 20 &&
-		mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT &&
-		mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
-	)
-fi
+# if [ $exitCode -eq 0 ]; then
+# 	echo "cleaning up DB"
+# 	mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
+# 	mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
+# else
+# 	echo -e "\033[0;31mTests failed: waiting 20s before cleaning the database (press ctrl-C to avoid cleanup)\033[0m"
+# 	echo "MongoDB database names: $LEAD_MONGO, $FOLLOW_MONGO"
+# 	(
+# 		sleep 20 &&
+# 		mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT &&
+# 		mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
+# 	)
+# fi
 
 exit $exitCode

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -39,8 +39,8 @@ if [ -n "$RUN_EXTERNAL" ]; then
 	cd ./node_modules/adex-validator-stack-test
 	LEADER_DATABASE=$LEAD_MONGO FOLLOWER_DATABASE=$FOLLOW_MONGO npm run test-local
 else 
-	./test/integration.js
 	./test/routes.js
+	./test/integration.js
 fi
 
 exitCode=$?

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -40,7 +40,7 @@ if [ -n "$RUN_EXTERNAL" ]; then
 	LEADER_DATABASE=$LEAD_MONGO FOLLOWER_DATABASE=$FOLLOW_MONGO npm run test-local
 else 
 	./test/integration.js
-	# ./test/routes.js
+	./test/routes.js
 fi
 
 exitCode=$?

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -48,18 +48,18 @@ exitCode=$?
 # end all jobs (sentries, workers)
 pkill -P $$
 
-# if [ $exitCode -eq 0 ]; then
-# 	echo "cleaning up DB"
-# 	mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
-# 	mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
-# else
-# 	echo -e "\033[0;31mTests failed: waiting 20s before cleaning the database (press ctrl-C to avoid cleanup)\033[0m"
-# 	echo "MongoDB database names: $LEAD_MONGO, $FOLLOW_MONGO"
-# 	(
-# 		sleep 20 &&
-# 		mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT &&
-# 		mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
-# 	)
-# fi
+if [ $exitCode -eq 0 ]; then
+	echo "cleaning up DB"
+	mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
+	mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
+else
+	echo -e "\033[0;31mTests failed: waiting 20s before cleaning the database (press ctrl-C to avoid cleanup)\033[0m"
+	echo "MongoDB database names: $LEAD_MONGO, $FOLLOW_MONGO"
+	(
+		sleep 20 &&
+		mongo $LEAD_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT &&
+		mongo $FOLLOW_MONGO --eval 'db.dropDatabase()' >$MONGO_OUT
+	)
+fi
 
 exit $exitCode

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -40,7 +40,7 @@ if [ -n "$RUN_EXTERNAL" ]; then
 	LEADER_DATABASE=$LEAD_MONGO FOLLOWER_DATABASE=$FOLLOW_MONGO npm run test-local
 else 
 	./test/integration.js
-	./test/routes.js
+	# ./test/routes.js
 fi
 
 exitCode=$?


### PR DESCRIPTION
Fixes #61 #65 
- [x] getLatestMsg - SHOULD RELY ON PROPER TIMESTAMP/SEQUENCE; maybe a primitive DB abstraction?
- [x] https://github.com/AdExNetwork/adex-validator-stack-js/issues/61
- [x] those tests should be more robust - and rely on some feedback messages from the validator stack #61 - perhaps `InvalidNewState` message
- [x] split tests in multiple files
- [ ] decrease repetitiveness in tests (DRY)
- [ ] ~~try to decrease waitTime/propagation logs~~ - leave this for later
- [x] tests: go through each one, try to break them by touching the code

