### PR TITLE
Fix withdrawal periods

### DIFF
--- a/middlewares/channel.js
+++ b/middlewares/channel.js
@@ -9,7 +9,7 @@ function channelLoad(req, res, next) {
 		.toArray()
 		.then(function(channels) {
 			if (!channels.length) {
-				res.sendStatus(404)
+				res.status(404).json(null)
 			} else {
 				req.channel = channels[0]
 				next()
@@ -24,7 +24,7 @@ function channelIfFind(cond, req, res, next) {
 		.countDocuments(cond, { limit: 1 })
 		.then(function(n) {
 			if (!n) {
-				res.sendStatus(404)
+				res.status(404).json(null)
 			} else {
 				next()
 			}
@@ -40,23 +40,4 @@ function channelIfActive(req, res, next) {
 	channelIfFind({ _id: req.params.id, 'spec.validators.id': req.whoami }, req, res, next)
 }
 
-// requires channelLoad
-function channelIfWithdraw(req, res, next) {
-	const { channel } = req
-	const { spec, validUntil } = channel
-	const currentTime = Date.now()
-	const isAllowedToSubmit = !spec.withdrawPeriodStart || currentTime < spec.withdrawPeriodStart
-	const withinTime = validUntil > currentTime / 1000
-
-	if (!isAllowedToSubmit || !withinTime) {
-		const message = 'channel cannnot update state, channel'
-		// prevent updating state
-		res.status(400).send({
-			message: `${message} ${!withinTime ? 'has expired' : 'in grace period'}`
-		})
-		return
-	}
-	next()
-}
-
-module.exports = { channelLoad, channelIfExists, channelIfActive, channelIfWithdraw }
+module.exports = { channelLoad, channelIfExists, channelIfActive }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-validator-stack",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "AdEx Validator stack (sentry, validator worker, watcher)",
   "main": "bin/sentry.js",
   "scripts": {

--- a/routes/channel.js
+++ b/routes/channel.js
@@ -41,14 +41,6 @@ router.post(
 	channelIfActive,
 	postEvents
 )
-router.post(
-	'/:id/events/close',
-	authRequired,
-	channelIfActive,
-	channelLoad,
-	allowOnlyCreator,
-	postEvents
-)
 
 // Implementations
 function getStatus(req, res) {
@@ -200,39 +192,16 @@ function postValidatorMessages(req, res, next) {
 
 function postEvents(req, res, next) {
 	const { events } = req.body
-
-	const isValid = Array.isArray(events) && events.every(isEventValid)
-	if (!isValid) {
-		res.sendStatus(400)
-		return
-	}
 	eventAggrService
 		.record(req.params.id, req.session.uid, events)
-		.then(function() {
-			res.send({ success: true })
+		.then(function(resp) {
+			res.status(resp.statusCode || 200).send(resp)
 		})
 		.catch(next)
 }
 
-// Helpers
-
-function isEventValid(ev) {
-	return ev && typeof ev.type === 'string'
-}
-
 function authRequired(req, res, next) {
 	if (!req.session) {
-		res.sendStatus(401)
-		return
-	}
-	next()
-}
-
-function allowOnlyCreator(req, res, next) {
-	const creator = req.channel.creator
-	const uid = req.session.uid
-
-	if (creator !== uid) {
 		res.sendStatus(401)
 		return
 	}

--- a/routes/channel.js
+++ b/routes/channel.js
@@ -3,12 +3,7 @@ const { celebrate } = require('celebrate')
 const schema = require('./schemas')
 const db = require('../db')
 const cfg = require('../cfg')
-const {
-	channelLoad,
-	channelIfExists,
-	channelIfActive,
-	channelIfWithdraw
-} = require('../middlewares/channel')
+const { channelLoad, channelIfExists, channelIfActive } = require('../middlewares/channel')
 const eventAggrService = require('../services/sentry/eventAggregator')
 
 const router = express.Router()
@@ -31,7 +26,6 @@ router.post(
 	authRequired,
 	celebrate({ body: schema.validatorMessage }),
 	channelLoad,
-	channelIfWithdraw,
 	postValidatorMessages
 )
 router.post(

--- a/routes/schemas.js
+++ b/routes/schemas.js
@@ -51,8 +51,7 @@ module.exports = {
 			adUnits: Joi.array().items(Joi.object()),
 			targeting: Joi.array().items(Joi.object()),
 			validators: validators(cfg),
-			withdrawPeriodStart: Joi.number()
-				.required(),
+			withdrawPeriodStart: Joi.number().required(),
 			minPerImpression: numericString.default('1'),
 			maxPerImpression: numericString.default('1'),
 			nonce: Joi.string(),
@@ -125,8 +124,7 @@ module.exports = {
 	events: {
 		events: Joi.array().items(
 			Joi.object({
-				type: Joi.string()
-					.required(),
+				type: Joi.string().required(),
 				publisher: Joi.string()
 			})
 		)

--- a/routes/schemas.js
+++ b/routes/schemas.js
@@ -126,7 +126,6 @@ module.exports = {
 		events: Joi.array().items(
 			Joi.object({
 				type: Joi.string()
-					.invalid(['CLOSE'])
 					.required(),
 				publisher: Joi.string()
 			})

--- a/services/sentry/eventAggregator.js
+++ b/services/sentry/eventAggregator.js
@@ -58,14 +58,19 @@ function makeRecorder(channelId) {
 		// that needs to be passed into the eventReducer
 		// this will probably be implemented an updateRecorder() function
 		return channelPromise.then(channel => {
+			if (userId !== channel.creator && events.find(e => e.type === 'CLOSE')) {
+				return { success: false, statusCode: 401 }
+			}
 			aggr = events.reduce(eventReducer.reduce.bind(null, userId, channel), aggr)
 			if (cfg.AGGR_THROTTLE) {
 				throttledPersistAndReset()
-				return Promise.resolve()
+				return Promise.resolve({ success: true })
 			}
 			const toSave = aggr
 			aggr = eventReducer.newAggr(channelId)
-			return eventAggrCol.insertOne(toSave)
+			return eventAggrCol
+				.insertOne(toSave)
+				.then(() => ({ success: true }))
 		})
 	}
 }

--- a/services/sentry/eventAggregator.js
+++ b/services/sentry/eventAggregator.js
@@ -68,9 +68,7 @@ function makeRecorder(channelId) {
 			}
 			const toSave = aggr
 			aggr = eventReducer.newAggr(channelId)
-			return eventAggrCol
-				.insertOne(toSave)
-				.then(() => ({ success: true }))
+			return eventAggrCol.insertOne(toSave).then(() => ({ success: true }))
 		})
 	}
 }

--- a/services/sentry/eventAggregator.js
+++ b/services/sentry/eventAggregator.js
@@ -61,6 +61,18 @@ function makeRecorder(channelId) {
 			if (userId !== channel.creator && events.find(e => e.type === 'CLOSE')) {
 				return { success: false, statusCode: 401 }
 			}
+			const currentTime = Date.now()
+			if (currentTime > channel.validUntil * 1000) {
+				return { success: false, statusCode: 400, message: 'channel is expired' }
+			}
+			if (
+				channel.spec.withdrawPeriodStart &&
+				currentTime > channel.spec.withdrawPeriodStart &&
+				!events.every(e => e.type === 'CLOSE')
+			) {
+				return { success: false, statusCode: 400, message: 'channel is past withdraw period' }
+			}
+
 			aggr = events.reduce(eventReducer.reduce.bind(null, userId, channel), aggr)
 			if (cfg.AGGR_THROTTLE) {
 				throttledPersistAndReset()

--- a/test/integration.js
+++ b/test/integration.js
@@ -414,7 +414,7 @@ tape('should close channel', async function(t) {
 	await postEvents(leaderUrl, channel.id, genEvents(10))
 
 	// close channel event
-	await fetchPost(`${leaderUrl}/channel/${channel.id}/events/close`, dummyVals.auth.creator, {
+	await fetchPost(`${leaderUrl}/channel/${channel.id}/events`, dummyVals.auth.creator, {
 		events: genEvents(1, null, 'CLOSE')
 	})
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,15 +5,7 @@ const { Channel, MerkleTree } = require('adex-protocol-eth/js')
 const { getStateRootHash } = require('../services/validatorWorker/lib')
 const SentryInterface = require('../services/validatorWorker/lib/sentryInterface')
 const dummyAdapter = require('../adapters/dummy')
-const {
-	forceTick,
-	wait,
-	postEvents,
-	genEvents,
-	getDummySig,
-	fetchPost,
-	parseResponse
-} = require('./lib')
+const { forceTick, wait, postEvents, genEvents, getDummySig, fetchPost } = require('./lib')
 const cfg = require('../cfg')
 const dummyVals = require('./prep-db/mongo')
 
@@ -120,14 +112,14 @@ tape('submit events and ensure they are accounted for', async function(t) {
 	t.end()
 })
 
-tape('should prevent submitting validator messages for expired channel', async function(t) {
+tape('should prevent submitting events for expired channel', async function(t) {
 	const channel = {
 		...dummyVals.channel,
 		id: 'expiredChannelTest',
-		validUntil: new Date().getTime() / 1000 + 3,
+		validUntil: Math.ceil(Date.now() / 1000) + 1,
 		spec: {
 			...dummyVals.channel.spec,
-			withdrawPeriodStart: new Date().getTime() + 2000
+			withdrawPeriodStart: Date.now() + 500
 		}
 	}
 
@@ -138,64 +130,43 @@ tape('should prevent submitting validator messages for expired channel', async f
 	])
 
 	// wait till channel expires
-	await wait(3000)
+	await wait(2100)
 
-	// submit validator channel
-	const { newState } = await iface.getLastApproved()
-
-	const response = await fetchPost(
-		`${followerUrl}/channel/${channel.id}/validator-messages`,
-		dummyVals.auth.follower,
-		{ messages: [newState.msg] }
-	).then(result => parseResponse(result))
-
-	t.equal(
-		response.message,
-		'channel cannnot update state, channel has expired',
-		'should prevent submitting message for an expired channel'
-	)
+	const resp = await postEvents(followerUrl, channel.id, genEvents(1)).then(r => r.json())
+	t.equal(resp.message, 'channel is expired', 'should prevent events after validUntil')
 	t.end()
 })
 
-tape(
-	'should prevent submitting validator messages for a channel in withdraw period',
-	async function(t) {
-		const channel = {
-			...dummyVals.channel,
-			id: 'withdrawPeriodTest',
-			validUntil: new Date().getTime() / 1000 + 20,
-			spec: {
-				...dummyVals.channel.spec,
-				withdrawPeriodStart: new Date().getTime() + 2000
-			}
+tape('should prevent submitting events for a channel in withdraw period', async function(t) {
+	const channel = {
+		...dummyVals.channel,
+		id: 'withdrawPeriodTest',
+		validUntil: Math.floor(Date.now() / 1000) + 20,
+		spec: {
+			...dummyVals.channel.spec,
+			withdrawPeriodStart: Date.now() + 1000
 		}
-
-		// Submit a new channel; we submit it to both sentries to avoid 404 when propagating messages
-		await Promise.all([
-			fetchPost(`${leaderUrl}/channel`, dummyVals.auth.leader, channel),
-			fetchPost(`${followerUrl}/channel`, dummyVals.auth.follower, channel)
-		])
-
-		// wait till withdrawPeriodStart reaches
-		await wait(2000)
-
-		const { newState } = await iface.getLastApproved()
-
-		const response = await fetchPost(
-			`${followerUrl}/channel/${channel.id}/validator-messages`,
-			dummyVals.auth.leader,
-			{ messages: [newState.msg] }
-		).then(result => parseResponse(result))
-
-		t.equal(
-			response.message,
-			'channel cannnot update state, channel in grace period',
-			'should prevent submitting message for an expired channel'
-		)
-
-		t.end()
 	}
-)
+
+	// Submit a new channel; we submit it to both sentries to avoid 404 when propagating messages
+	await Promise.all([
+		fetchPost(`${leaderUrl}/channel`, dummyVals.auth.leader, channel),
+		fetchPost(`${followerUrl}/channel`, dummyVals.auth.follower, channel)
+	])
+
+	// wait till withdrawPeriodStart
+	await wait(1100)
+
+	const resp = await postEvents(followerUrl, channel.id, genEvents(1)).then(r => r.json())
+	t.equal(
+		resp.message,
+		'channel is past withdraw period',
+		'should prevent events after withdraw period'
+	)
+	// @TODO we can still submit validator messages
+
+	t.end()
+})
 
 tape('new states are not produced when there are no new aggregates', async function(t) {
 	const url = `${leaderUrl}/channel/${dummyVals.channel.id}/validator-messages`

--- a/test/lib.js
+++ b/test/lib.js
@@ -16,13 +16,6 @@ function fetchPost(url, authToken, body) {
 	})
 }
 
-function parseResponse(response) {
-	if (!response.ok) {
-		return response.text().then(error => JSON.parse(error))
-	}
-	return response.json()
-}
-
 function postEvents(url, channelId, events) {
 	return fetchPost(`${url}/channel/${channelId}/events`, dummyVals.auth.user, { events })
 }
@@ -70,6 +63,5 @@ module.exports = {
 	getDummySig,
 	forceTick,
 	wait,
-	fetchPost,
-	parseResponse
+	fetchPost
 }

--- a/test/routes.js
+++ b/test/routes.js
@@ -91,7 +91,7 @@ tape('POST /channel/{id}/events: malformed events', async function(t) {
 
 tape('POST /channel/{id}/{events,validator-messages}: wrong authentication', async function(t) {
 	await Promise.all(
-		['events', 'validator-messages', 'events/close'].map(path =>
+		['events', 'validator-messages'].map(path =>
 			fetchPost(`${leaderUrl}/channel/${dummyVals.channel.id}/${path}`, `WRONG AUTH`, {
 				messages: []
 			}).then(function(resp) {
@@ -102,9 +102,9 @@ tape('POST /channel/{id}/{events,validator-messages}: wrong authentication', asy
 	t.end()
 })
 
-tape('POST /channel/{id}/events/close: a publisher but not a creator', async function(t) {
+tape('POST /channel/{id}/events: CLOSE: a publisher but not a creator', async function(t) {
 	await fetchPost(
-		`${leaderUrl}/channel/${dummyVals.channel.id}/events/close`,
+		`${leaderUrl}/channel/${dummyVals.channel.id}/events`,
 		dummyVals.auth.publisher,
 		{
 			events: [{ type: 'CLOSE' }]

--- a/test/routes.js
+++ b/test/routes.js
@@ -2,7 +2,7 @@
 
 const tape = require('tape-catch')
 const fetch = require('node-fetch')
-const { postEvents, fetchPost, parseResponse } = require('./lib')
+const { postEvents, fetchPost } = require('./lib')
 
 // const cfg = require('../cfg')
 const dummyVals = require('./prep-db/mongo')
@@ -126,8 +126,8 @@ tape('Should not create channel with invalid withdrawPeriodStart', async functio
 			]
 		}
 	}
-	const resp = await fetchPost(`${followerUrl}/channel`, dummyVals.auth.leader, channel).then(res =>
-		parseResponse(res)
+	const resp = await fetchPost(`${followerUrl}/channel`, dummyVals.auth.leader, channel).then(r =>
+		r.json()
 	)
 	t.equal(
 		resp.message,

--- a/test/routes.js
+++ b/test/routes.js
@@ -103,13 +103,9 @@ tape('POST /channel/{id}/{events,validator-messages}: wrong authentication', asy
 })
 
 tape('POST /channel/{id}/events: CLOSE: a publisher but not a creator', async function(t) {
-	await fetchPost(
-		`${leaderUrl}/channel/${dummyVals.channel.id}/events`,
-		dummyVals.auth.publisher,
-		{
-			events: [{ type: 'CLOSE' }]
-		}
-	).then(function(resp) {
+	await fetchPost(`${leaderUrl}/channel/${dummyVals.channel.id}/events`, dummyVals.auth.publisher, {
+		events: [{ type: 'CLOSE' }]
+	}).then(function(resp) {
 		t.equal(resp.status, 401, 'status must be Unauthorized')
 	})
 	t.end()


### PR DESCRIPTION
This contains two important fixes

* Withdrawal period passing should disable submitting events, but not disable validator messages
* rewrote how CLOSE event is authenticated to avoid hacks, apply schema on all events